### PR TITLE
Fix for TypeError issues #20

### DIFF
--- a/Source/Our.Umbraco.RedirectsViewer/Web/App_Plugins/RedirectsViewer/views/create-overlay.html
+++ b/Source/Our.Umbraco.RedirectsViewer/Web/App_Plugins/RedirectsViewer/views/create-overlay.html
@@ -1,9 +1,9 @@
 ﻿<div ng-controller="Our.Umbraco.RedirectsViewer.CreateOverlayController as vm" class="umb-el-wrap">
-    <form name="settingsForm" val-form-manager >   
-        <div style="margin-top: 20px;">     
-            <umb-property property="vm.properties.OldUrl">
+    <form name="settingsForm" val-form-manager >
+        <div style="margin-top: 20px;">
+            <umb-property property="vm.properties.OldUrl" property-alias="oldUrl">
                 <input type="text" ng-model="vm.model.OldUrl" class="umb-property-editor umb-textstring textstring" required no-dirty-check/>
-            </umb-property>      
+            </umb-property>
         </div>
     </form>
 </div>

--- a/Source/Our.Umbraco.RedirectsViewer/Web/App_Plugins/RedirectsViewer/views/settings-dashboard.html
+++ b/Source/Our.Umbraco.RedirectsViewer/Web/App_Plugins/RedirectsViewer/views/settings-dashboard.html
@@ -12,13 +12,13 @@
 
         </umb-box-header>
         <umb-box-content>
-            <umb-property property="vm.properties.AllowPermission">
+            <umb-property property="vm.properties.AllowPermission" property-alias="allowPermission">
                 <umb-toggle checked="vm.settings.create.allowed"
                             on-click="vm.toggleCreateAllowed()">
 
                 </umb-toggle>
             </umb-property>
-            <umb-property property="vm.properties.GroupPermissions" ng-if="vm.settings.create.allowed">
+            <umb-property property="vm.properties.GroupPermissions" property-alias="groupPermissions" ng-if="vm.settings.create.allowed">
                 <div class="umb-table">
                     <div class="umb-table-body">
                         <div class="umb-table-row" ng-repeat="item in vm.createGroups">
@@ -34,8 +34,7 @@
                         </div>
                     </div>
                 </div>
-
-            </umb-property>           
+            </umb-property>
         </umb-box-content>
     </umb-box>
     <umb-box ng-if="!vm.loading">
@@ -43,13 +42,13 @@
 
         </umb-box-header>
         <umb-box-content>
-            <umb-property property="vm.properties.AllowPermission">
+            <umb-property property="vm.properties.AllowPermission" property-alias="allowPermission">
                 <umb-toggle checked="vm.settings.delete.allowed"
                             on-click="vm.toggleDeleteAllowed()">
 
                 </umb-toggle>
             </umb-property>
-            <umb-property property="vm.properties.GroupPermissions" ng-if="vm.settings.delete.allowed">
+            <umb-property property="vm.properties.GroupPermissions" property-alias="groupPermissions" ng-if="vm.settings.delete.allowed">
                 <div class="umb-table">
                     <div class="umb-table-body">
                         <div class="umb-table-row" ng-repeat="item in vm.deleteGroups">
@@ -65,8 +64,8 @@
                         </div>
                     </div>
                 </div>
-
-            </umb-property></umb-box-content>
+            </umb-property>
+        </umb-box-content>
     </umb-box>
     <div>
         <umb-button type="button"


### PR DESCRIPTION
I noticed these TypeError issues were triggered by both the settings dashboard and the create overlay for RedirectsViewer. I was able to fix this issue by adding a `property-alias` attribute to all `<umb-property />` tags.