### PR TITLE
Remove double attribute causing an error when deleting a redirect

### DIFF
--- a/Source/Our.Umbraco.RedirectsViewer/Controllers/RedirectsApiController.cs
+++ b/Source/Our.Umbraco.RedirectsViewer/Controllers/RedirectsApiController.cs
@@ -142,7 +142,6 @@
         /// <returns>
         /// The <see cref="HttpResponseMessage"/>.
         /// </returns>
-        [HttpPost]
         [HttpDelete]
         public HttpResponseMessage DeleteRedirect(Guid id)
         {


### PR DESCRIPTION
Request error: The URL returned a 404 (not found):
/umbraco/BackOffice/Api/RedirectsApi/DeleteRedirect

![image](https://user-images.githubusercontent.com/3933562/168577708-77c93c99-f058-4489-a778-e1e25f8ece91.png)
